### PR TITLE
Fix italy dial code

### DIFF
--- a/lib/src/country.dart
+++ b/lib/src/country.dart
@@ -951,7 +951,7 @@ enum Country {
   italy._(
     "Italy",
     "IT",
-    "39",
+    "+39",
     "🇮🇹",
     Currency.eur,
   ),


### PR DESCRIPTION
The code should be `+39` and not `39`